### PR TITLE
Extend configuration options

### DIFF
--- a/Tasks/NewsMover.cs
+++ b/Tasks/NewsMover.cs
@@ -19,6 +19,7 @@ namespace Sitecore.Sharedsource.Tasks
     using Sitecore.Pipelines;
     using Sitecore.Sharedsource.NewsMover;
     using Sitecore.Sharedsource.NewsMover.Pipelines;
+    using System.Linq;
 
     public class NewsMover
     {
@@ -126,8 +127,17 @@ namespace Sitecore.Sharedsource.Tasks
 
             _inProcess.Add(item.ID);
             TemplateConfiguration config = Templates[item.TemplateID];
-            DateTime articleDate = EnsureAndGetDate(item, config.DateField);
-            OrganizeItem(item, config, articleDate);
+            bool organize = true;
+            if (config.Roots != null && config.Roots.Count > 0)
+            {
+                organize = config.Roots.Any(x => x.Axes.IsAncestorOf(item));
+            }
+
+            if (organize)
+            {
+                DateTime articleDate = EnsureAndGetDate(item, config.DateField);
+                OrganizeItem(item, config, articleDate);
+            }
             _inProcess.Remove(item.ID);
         }
 
@@ -213,6 +223,15 @@ namespace Sitecore.Sharedsource.Tasks
                 if (config.DayFolder != null)
                 {
                     root = GetOrCreateChild(root, config.DayFolder.Template, config.DayFolder.GetName(articleDate), config.SortOrder);
+                    if (config.HourFolder != null)
+                    {
+                        root = GetOrCreateChild(root, config.HourFolder.Template, config.HourFolder.GetName(articleDate), config.SortOrder);
+
+                        if (config.MinuteFolder != null)
+                        {
+                            root = GetOrCreateChild(root, config.MinuteFolder.Template, config.MinuteFolder.GetName(articleDate), config.SortOrder);
+                        }
+                    }
                 }
             }
 

--- a/Tasks/TemplateConfigurationBuilder.cs
+++ b/Tasks/TemplateConfigurationBuilder.cs
@@ -35,6 +35,7 @@ namespace Sitecore.Sharedsource.Tasks
             string monthTemplate = null, monthFormat = null;
             string dayTemplate = null, dayFormat = null;
             string dateField = configNode["DateField"].InnerText;
+            string roots = "";
 
             Sitecore.Diagnostics.Assert.IsNotNullOrEmpty(template, "Template");
             Sitecore.Diagnostics.Assert.IsNotNullOrEmpty(yearTemplate, "YearTemplate");
@@ -61,6 +62,11 @@ namespace Sitecore.Sharedsource.Tasks
                 dayFormat = configNode["DayTemplate"].GetAttributeWithDefault("formatString", "dd");
             }
 
+            if (configNode["Roots"] != null)
+            {
+                roots = configNode["Roots"].InnerText;                
+            }
+
 
             string sort = configNode.GetAttributeWithDefault("sort", null);
             SortOrder s = SortOrder.None;
@@ -69,7 +75,7 @@ namespace Sitecore.Sharedsource.Tasks
                 s.TryParse(sort, true, out s);
             }
 
-            return new TemplateConfiguration(database, template, dateField, yearTemplate, monthTemplate, dayTemplate, s, yearFormat, monthFormat, dayFormat);
+            return new TemplateConfiguration(database, template, dateField, yearTemplate, monthTemplate, dayTemplate, s, yearFormat, monthFormat, dayFormat,roots);
         }
     }
 }


### PR DESCRIPTION
Support for minutes and seconds folders per template. Let you decide if you want to create more granular folders.
Support for multi root definition by template. Let you specify one or more root items per template. Useful if you only want to move items under specific folders
