### PR TITLE
Added functionality to create folder structure with first character of an item name and move item into that folder.

### DIFF
--- a/App_Config/Include/NewsMover.config
+++ b/App_Config/Include/NewsMover.config
@@ -42,6 +42,17 @@
               <MonthTemplate formatString="MMMM">Common/Folder</MonthTemplate>
               <DayTemplate formatString="dd">Common/Folder</DayTemplate>
             </template>
+
+
+            <!-- If you want to create folder structure with first character of item name then use below configrations
+            Define a template configuration.
+              @id: [required] Any item based on the configured template will be ogranized
+              @sort: [optional] How to configure the sorting of 'folders' and the item (Ascending, Descending, null)
+                FolderTemplate: [required] The template to use for creating 'folders'
+            -->
+            <template id="Page Types/Detail Page" sort="Ascending">
+              <FolderTemplate>Common/Folder</FolderTemplate>
+            </template>
             
           </templates>
          

--- a/Tasks/Folder.cs
+++ b/Tasks/Folder.cs
@@ -40,6 +40,13 @@ namespace Sitecore.Sharedsource.Tasks
             FormatString = format;
         }
 
+        public Folder(TemplateItem templateItem)
+        {
+            Sitecore.Diagnostics.Assert.IsNotNull(templateItem, "templateItem");
+
+            Template = templateItem;
+        }
+
         /// <summary>
         /// Gets the name of the folder.
         /// </summary>
@@ -48,6 +55,16 @@ namespace Sitecore.Sharedsource.Tasks
         public string GetName(DateTime date)
         {
             return date.ToString(FormatString);
+        }
+
+        /// <summary>
+        /// Gets the name of the folder.
+        /// </summary>
+        /// <param name="itemName">The itemName.</param>
+        /// <returns></returns>
+        public string GetName(string itemName)
+        {
+            return itemName[0].ToString();
         }
     }
 }

--- a/Tasks/TemplateConfiguration.cs
+++ b/Tasks/TemplateConfiguration.cs
@@ -20,7 +20,7 @@ namespace Sitecore.Sharedsource.Tasks
     public class TemplateConfiguration
     {
         private Database _database;
-        private string _template, _yearTemplate, _monthTemplate, _dayTemplate;
+        private string _template, _yearTemplate, _monthTemplate, _dayTemplate, _folderTemplate;
         private string _yearFormat = "yyyy", _monthFormat = "MM", _dayFormat = "dd";
         
         /// <summary>
@@ -32,6 +32,11 @@ namespace Sitecore.Sharedsource.Tasks
         /// Gets the year folder.
         /// </summary>
         public Folder YearFolder { get; private set; }
+
+        /// <summary>
+        /// Gets the folder.
+        /// </summary>
+        public Folder Folder { get; private set; }
 
         /// <summary>
         /// Gets the month folder.
@@ -66,12 +71,12 @@ namespace Sitecore.Sharedsource.Tasks
         /// <param name="yearFormat">The year format.</param>
         /// <param name="monthFormat">The month format.</param>
         /// <param name="dayFormat">The day format.</param>
-        internal TemplateConfiguration(Database database, string template, string dateField, string yearTemplate, string monthTemplate, string dayTemplate, SortOrder sort = SortOrder.None, string yearFormat = "yyyy", string monthFormat = "MM", string dayFormat = "dd")
+        internal TemplateConfiguration(Database database, string template, string dateField, string yearTemplate, string monthTemplate, string dayTemplate, string folderTemplate, SortOrder sort = SortOrder.None, string yearFormat = "yyyy", string monthFormat = "MM", string dayFormat = "dd")
         {
             Sitecore.Diagnostics.Assert.IsNotNull(database, "Database");
             Sitecore.Diagnostics.Assert.IsNotNullOrEmpty(template, "Template");
-            Sitecore.Diagnostics.Assert.IsNotNullOrEmpty(dateField, "DateField");
-            Sitecore.Diagnostics.Assert.IsNotNullOrEmpty(yearTemplate, "YearTemplate");
+            //Sitecore.Diagnostics.Assert.IsNotNullOrEmpty(dateField, "DateField");
+            //Sitecore.Diagnostics.Assert.IsNotNullOrEmpty(yearTemplate, "YearTemplate");
 
             _database = database;
             _template = template;
@@ -81,6 +86,7 @@ namespace Sitecore.Sharedsource.Tasks
             _yearFormat = yearFormat;
             _monthFormat = monthFormat;
             _dayFormat = dayFormat;
+            _folderTemplate = folderTemplate;
             DateField = dateField;
             SortOrder = sort;
 
@@ -95,8 +101,17 @@ namespace Sitecore.Sharedsource.Tasks
             // make sure we have the template of the items we want to move
             Template = _database.Templates[_template];
 
-            // we at least need a year template
-            YearFolder = new Folder(_database.Templates[_yearTemplate], _yearFormat);
+            if (!string.IsNullOrEmpty(_folderTemplate))
+            {
+                // we at least need a year template
+                Folder = new Folder(_database.Templates[_folderTemplate]);
+            }
+
+            if (!string.IsNullOrEmpty(_yearTemplate))
+            {
+                // we at least need a year template
+                YearFolder = new Folder(_database.Templates[_yearTemplate], _yearFormat);
+            }
 
             // we may want to organize in months too
             if (!string.IsNullOrEmpty(_monthTemplate))

--- a/Tasks/TemplateConfigurationBuilder.cs
+++ b/Tasks/TemplateConfigurationBuilder.cs
@@ -24,29 +24,41 @@ namespace Sitecore.Sharedsource.Tasks
         /// <param name="database">The database.</param>
         /// <param name="configNode">The config node.</param>
         /// <returns></returns>
+        /// <summary>
         public static TemplateConfiguration Create(Database database, XmlNode configNode)
         {
             Sitecore.Diagnostics.Assert.IsNotNull(database, "Database");
             Sitecore.Diagnostics.Assert.IsNotNull(configNode, "XmlNode");
 
             string template = configNode.Attributes["id"].Value;
-            string yearTemplate = configNode["YearTemplate"].InnerText;
-            string yearFormat = configNode["YearTemplate"].GetAttributeWithDefault("formatString", "yyyy");
+            string yearTemplate = null;
+            string folderTemplate = null;
+            string yearFormat = null;
             string monthTemplate = null, monthFormat = null;
             string dayTemplate = null, dayFormat = null;
-            string dateField = configNode["DateField"].InnerText;
+            string dateField = null;
 
             Sitecore.Diagnostics.Assert.IsNotNullOrEmpty(template, "Template");
-            Sitecore.Diagnostics.Assert.IsNotNullOrEmpty(yearTemplate, "YearTemplate");
-            Sitecore.Diagnostics.Assert.IsNotNullOrEmpty(dateField, "DateField");
+            //Sitecore.Diagnostics.Assert.IsNotNullOrEmpty(yearTemplate, "YearTemplate");
+            //Sitecore.Diagnostics.Assert.IsNotNullOrEmpty(dateField, "DateField");
 
             // make sure we have the template of the items we want to move
             TemplateItem templateItem = database.Templates[template];
 
+            if (configNode["DateField"] != null)
+            {
+                dateField = configNode["DateField"].InnerText;
+            }
             if (templateItem == null)
             {
                 Sitecore.Diagnostics.Log.Warn(string.Format("Template '{0}' not found.", template), configNode);
                 return null;
+            }
+
+            if (configNode["YearTemplate"] != null)
+            {
+                monthTemplate = configNode["YearTemplate"].InnerText;
+                monthFormat = configNode["YearTemplate"].GetAttributeWithDefault("formatString", "yyyy");
             }
 
             if (configNode["MonthTemplate"] != null)
@@ -60,16 +72,19 @@ namespace Sitecore.Sharedsource.Tasks
                 dayTemplate = configNode["DayTemplate"].InnerText;
                 dayFormat = configNode["DayTemplate"].GetAttributeWithDefault("formatString", "dd");
             }
-
+            if (configNode["FolderTemplate"] != null)
+            {
+                folderTemplate = configNode["FolderTemplate"].InnerText;
+            }
 
             string sort = configNode.GetAttributeWithDefault("sort", null);
             SortOrder s = SortOrder.None;
             if (!string.IsNullOrEmpty(sort))
             {
-                s.TryParse(sort, true, out s);
+                EnumExtensions.TryParse(s, sort, true, out s);
             }
 
-            return new TemplateConfiguration(database, template, dateField, yearTemplate, monthTemplate, dayTemplate, s, yearFormat, monthFormat, dayFormat);
+            return new TemplateConfiguration(database, template, dateField, yearTemplate, monthTemplate, dayTemplate, folderTemplate, s, yearFormat, monthFormat, dayFormat);
         }
     }
 }


### PR DESCRIPTION
Added functionality to create folders with first character of an item name. For example if someone don't have date field on item but he still want a good architecture like folder with first character of item name and then item should be inside that folder. as given below - 
product listing (landing page)
    - a (Folder)
      - - att
      - - add
- b (Folder)
  - \- byy
  - \- bnn

So now we have alphabetically folder structure also with date time architecture!!   
